### PR TITLE
Support charset in content-type headers

### DIFF
--- a/src/JSONxRequestAdaptor.php
+++ b/src/JSONxRequestAdaptor.php
@@ -21,7 +21,9 @@ class JSONxRequestAdaptor {
 	{
 		if ($this->givingXml($request))
 		{
-			$request->headers->set('Content-Type', 'application/json');
+			$charset = $this->getCharset($request);
+
+			$request->headers->set('Content-Type', 'application/json' . ($charset ? '; ' . $charset : ''));
 			$request->replace($this->fromJSONx($request));
 		}
 
@@ -30,7 +32,17 @@ class JSONxRequestAdaptor {
 
 	private function givingXml(Request $request)
 	{
-		return $request->header('Content-Type') === 'application/xml';
+		return substr($request->headers->get('Content-Type'), 0, 15) === 'application/xml';
+	}
+
+	private function getCharset(Request $request)
+	{
+		$pos = strpos($request->headers->get('Content-Type'), 'charset');
+
+		if ($pos !== false)
+		{
+			return substr($request->headers->get('Content-Type'), $pos);
+		}
 	}
 
 	/**

--- a/src/JSONxResponseAdaptor.php
+++ b/src/JSONxResponseAdaptor.php
@@ -30,7 +30,7 @@ class JSONxResponseAdaptor {
 				return new Response(
 					$this->converter->toJSONx($response->getOriginalContent()),
 					$response->getStatusCode(),
-					array_merge($response->headers->all(), ['Content-Type' => 'application/xml'])
+					array_merge($response->headers->all(), ['Content-Type' => $this->appendCharset($response, 'application/xml')])
 				);
 			}
 			else if ($response instanceof JsonResponse)
@@ -38,7 +38,7 @@ class JSONxResponseAdaptor {
 				return new Response(
 					$this->converter->toJSONx(json_decode($response->getContent())),
 					$response->getStatusCode(),
-					array_merge($response->headers->all(), ['Content-Type' => 'application/xml'])
+					array_merge($response->headers->all(), ['Content-Type' => $this->appendCharset($response, 'application/xml')])
 				);
 			}
 			else
@@ -61,7 +61,18 @@ class JSONxResponseAdaptor {
 
 	private function providingJson(Response $response)
 	{
-		return $response->headers->get('Content-Type') === 'application/json';
+		return substr($response->headers->get('Content-Type'), 0, 16) === 'application/json';
 	}
 
+	private function appendCharset($response, $contentType)
+	{
+		$pos = strpos($response->headers->get('Content-Type'), 'charset');
+
+		if ($pos !== false)
+		{
+			return $contentType . '; ' . substr($response->headers->get('Content-Type'), $pos);
+		}
+
+		return $contentType;
+	}
 }

--- a/tests/JSONxRequestAdaptorTest.php
+++ b/tests/JSONxRequestAdaptorTest.php
@@ -50,6 +50,16 @@ class JSONxRequestAdaptorTest extends TestCase {
 		$this->assertEquals('!!!', $out->input('hello.world'));
 	}
 
+	public function testItConvertsRequestsWithXmlAndCharset()
+	{
+		$request = $this->makeRequest($this->toJSONx(['city' => 'Portsmouth']));
+		$request->headers->set('Content-Type', 'application/xml; charset=UTF-8');
+
+		$out = $this->go(clone $request);
+
+		$this->assertEquals('application/json; charset=UTF-8', $out->header('Content-Type'));
+	}
+
 	private function go(Request $request)
 	{
 		return (new JSONxRequestAdaptor(new JSONx))->handle($request);

--- a/tests/JSONxResponseAdaptorTest.php
+++ b/tests/JSONxResponseAdaptorTest.php
@@ -75,6 +75,22 @@ class JSONxResponseAdaptorTest extends TestCase {
 		$this->assertEquals($response, $out);
 	}
 
+	public function testItConvertsResponsesWithContentTypeAndCharset()
+	{
+		$request = $this->makeRequest();
+		$request->headers->set('Accept', 'application/xml');
+
+		$response = new Response(['city' => 'Portsmouth'], 200);
+		$response->headers->set('Content-Type', 'application/json; charset=UTF-8');
+
+		$out = $this->go($request, clone $response);
+
+		$this->assertInstanceOf(Response::class, $out);
+		$this->assertEquals(200, $out->getStatusCode());
+		$this->assertEquals('application/xml; charset=UTF-8', $out->headers->get('Content-Type'));
+		$this->assertXmlStringEqualsXmlString($this->toJSONx(['city' => 'Portsmouth']), $out->getContent());
+	}
+
 	private function go(Request $request, $response)
 	{
 		return (new JSONxResponseAdaptor(new JSONx))->handle($request, $response);


### PR DESCRIPTION
`laravel/passport` appends a charset to the `Content-Type` header which breaks automatic JSONx conversion.

This PR adds supports for requests with a charset in the content type, previously it would just ignore the requests as it didn't detect the content type correctly. Also adds support to preserve the charset in responses after conversion. 